### PR TITLE
rename radae_nopy to rade_c in workflow

### DIFF
--- a/.github/workflows/run_ctest.yml
+++ b/.github/workflows/run_ctest.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - name: Checkout radae_nopy code
+      - name: Checkout rade_c code
         uses: actions/checkout@v4
         with:
-          path: ${{github.workspace}}/radae_nopy
+          path: ${{github.workspace}}/rade_c
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -26,16 +26,16 @@ jobs:
         shell: bash
         run: |
           sudo apt update
-          sudo apt install octave octave-common octave-signal sox cmake git python3.10-dev
+          sudo apt install octave octave-common octave-signal sox cmake git
 
       - name: Install python packages
         shell: bash
         run: |
           pip3 install torch numpy matplotlib tqdm
 
-      - name: Build radae_nopy
+      - name: Build rade_c
         shell: bash
-        working-directory: ${{github.workspace}}/radae_nopy
+        working-directory: ${{github.workspace}}/rade_c
         run: |
           mkdir build
           cd build
@@ -55,11 +55,11 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DRADAE_NOPY_BUILD_DIR=${{github.workspace}}/radae_nopy/build ..
+          cmake -DRADE_C_BUILD_DIR=${{github.workspace}}/rade_c/build ..
           make
 
       - name: Run ctests
         shell: bash
         working-directory: ${{github.workspace}}/radae/build
         run: |
-          ctest -V --output-on-failure -R radae_nopy
+          ctest -V --output-on-failure -R rade_c

--- a/README.md
+++ b/README.md
@@ -196,7 +196,17 @@ This matches the Python reference result (loss: 0.081) to within ±10%. When tes
 
 ## Automated Testing
 
-A suite of tests runs on every GitHub push. They can also be run [locally](https://github.com/drowe67/radae/pull/66).
+A suite of ctests runs automatically on every GitHub push (Linux x86 and ARM). The tests cover V1 and V2 encode/decode pipelines, channel conditions (AWGN, MPP, MPG, MPD), acquisition, SNR estimation, EOO detection, BER, and the WAV convenience tools.
+
+To run the tests locally, the [radae](https://github.com/drowe67/radae) Python reference repo is required:
+
+```
+cd ~
+git clone https://github.com/drowe67/radae.git
+cd radae && mkdir build && cd build
+cmake -DRADE_C_BUILD_DIR=~/rade_c/build ..
+ctest -R rade_c
+```
 
 ## Directory Structure
 


### PR DESCRIPTION
Bringing ctest names, ENV variables into line with C Port rename.