### PR TITLE
V2 rx: enable coarse CP timing adjustment by default

### DIFF
--- a/src/rade_rx_v2.c
+++ b/src/rade_rx_v2.c
@@ -108,6 +108,14 @@ int rade_rx_v2_init(rade_rx_v2_state *rx, int bpf_en) {
     rx->hangover = 75;
     rx->nin      = RADE_V2_SYM_LEN;
 
+    /* Enable coarse CP timing adjustment. Matches rx2.py's default
+       (--timing_adj_at 0), which the driver script uses to set
+       receiver.timing_adj = 1 almost immediately (once s > 0). Without
+       this, adjust_timing() is never invoked and the receiver is stuck
+       with whatever sub-symbol sample-phase timing offset it happened
+       to acquire on. */
+    rx->timing_adj = 1;
+
     /* AGC on by default. Target RMS is the nominal peak level (1.0) backed
        off by the ~3dB PAPR, matching radae_v2.py's agc_target. */
     rx->agc_en     = 1;


### PR DESCRIPTION
## Summary
- `rx->timing_adj` gates `adjust_timing()` in `rade_rx_v2.c` (the coarse +/-40 sample CP-centering correction), but it was never set anywhere in the C port (`rade_rx_v2_init`, `rade_api.c`, `rade_rx_wav.c`) — it stayed at its zero-initialized value, so `adjust_timing()` was dead code.
- The receiver would lock onto whatever sub-symbol sample-phase timing offset the CP autocorrelation peak happened to land on at acquisition and keep it uncorrected for the rest of the session.
- Found via a sweep test that prepends 1-40ms of silence before a TX burst and measures loss vs. baseline: loss showed a periodic bump (period exactly 160 samples / 20ms = `RADE_V2_SYM_LEN`), peaking at +15% above baseline — enough to fail a +/-10% verification gate.
- The Python reference (`rx2.py` in drowe67/radae, `dr-radev2` branch) enables this almost immediately by default via `--timing_adj_at 0` (`receiver.timing_adj = 1` once `s > 0`). This change mirrors that by enabling it unconditionally in `rade_rx_v2_init()`.

## Test plan
- [x] Rebuilt `rade_rx_wav`/`rade_tx_wav` and reran the 1-40ms offset sweep against `wav/all.wav`: peak loss dropped from 0.094 (+14.6%) to 0.091 (+11%), and violations of the +/-10% baseline dropped from ~14/40 offsets to 2/40.
- [ ] Run the full `ctest -R rade_c` suite against the `radae` Python reference repo to confirm no regressions in the existing V2 acquisition/BER/EOO tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET7KCA5GV1au8W5ubK1pGv