### PR TITLE
V2 BPF/timing investigation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(rade_tx_wav rade opus m)
 add_executable(rade_bpf_test rade_bpf_test.c kiss_fft.c kiss_fftr.c)
 target_link_libraries(rade_bpf_test rade opus m)
 
+add_executable(rade_bpf_filter rade_bpf_filter.c)
+target_link_libraries(rade_bpf_filter rade m)
+
 # BER test tool: QPSK symbol BER test for modem equalisation code
 add_executable(rade_ber_test rade_ber_test.c)
 target_link_libraries(rade_ber_test rade m)

--- a/src/radae_rx.c
+++ b/src/radae_rx.c
@@ -52,6 +52,11 @@ void usage(void) {
     fprintf(stderr, "  --write_snr_est FILE    Write per-symbol SNR estimates (float32) to FILE (V2 only)\n");
     fprintf(stderr, "  --gain GAIN             Manual gain applied to rx samples before decoding (default 1.0)\n");
     fprintf(stderr, "  --agc 0|1               Enable/disable input AGC (V2 only, default: on)\n");
+    fprintf(stderr, "  --no_bpf                Disable input BPF (V2 only)\n");
+    fprintf(stderr, "  --no_timing_adj         Disable timing adjustment (V2 only)\n");
+    fprintf(stderr, "  --no_freq_corr          Disable frequency offset correction (V2 only)\n");
+    fprintf(stderr, "  --impulse_bpf           Replace BPF with pure 50-sample delay h[50]=1 (V2 only)\n");
+    fprintf(stderr, "  --write_bpf_out FILE    Write post-BPF IQ samples (complex float32) to FILE (V2 only)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Reads IQ samples from stdin, writes vocoder features to stdout.\n");
     fprintf(stderr, "Input format: complex float32 (interleaved I,Q)\n");
@@ -65,6 +70,11 @@ int main(int argc, char *argv[]) {
     char *snr_est_fn = NULL;
     float gain = 1.0f;
     int agc = -1;  /* -1 = leave library default (on) */
+    int no_bpf = 0;
+    int no_timing_adj = 0;
+    int no_freq_corr = 0;
+    int impulse_bpf = 0;
+    char *write_bpf_out = NULL;
 
     static struct option long_options[] = {
         {"help",           no_argument,       NULL, 'h'},
@@ -74,6 +84,11 @@ int main(int argc, char *argv[]) {
         {"write_snr_est",  required_argument, NULL, 's'},
         {"gain",           required_argument, NULL, 'g'},
         {"agc",            required_argument, NULL, 'a'},
+        {"no_bpf",         no_argument,       NULL, 'B'},
+        {"no_timing_adj",  no_argument,       NULL, 'T'},
+        {"no_freq_corr",   no_argument,       NULL, 'F'},
+        {"impulse_bpf",    no_argument,       NULL, 'I'},
+        {"write_bpf_out",  required_argument, NULL, 'W'},
         {NULL,             0,                 NULL, 0}
     };
 
@@ -85,11 +100,13 @@ int main(int argc, char *argv[]) {
         case 'm':
             model_name = optarg;
             break;
-        case 'v':
-            if (atoi(optarg) == 0) {
-                flags |= RADE_VERBOSE_0;
-            }
+        case 'v': {
+            int v = atoi(optarg);
+            if (v == 0)      flags |= RADE_VERBOSE_0;
+            else if (v == 2) flags |= RADE_VERBOSE_TERSE;
+            else if (v >= 3) flags |= RADE_VERBOSE_FULL;
             break;
+        }
         case 'd':
             disable_unsync = atof(optarg);
             break;
@@ -104,6 +121,21 @@ int main(int argc, char *argv[]) {
             break;
         case 'a':
             agc = atoi(optarg);
+            break;
+        case 'B':
+            no_bpf = 1;
+            break;
+        case 'T':
+            no_timing_adj = 1;
+            break;
+        case 'F':
+            no_freq_corr = 1;
+            break;
+        case 'I':
+            impulse_bpf = 1;
+            break;
+        case 'W':
+            write_bpf_out = optarg;
             break;
         default:
             usage();
@@ -131,6 +163,32 @@ int main(int argc, char *argv[]) {
     if (agc >= 0) {
         rade_rx_set_agc(r, agc);
         fprintf(stderr, "agc: %d\n", agc);
+    }
+    if (no_bpf) {
+        rade_rx_set_bpf(r, 0);
+        fprintf(stderr, "BPF disabled\n");
+    }
+    if (no_timing_adj) {
+        rade_rx_set_timing_adj(r, 0);
+        fprintf(stderr, "timing_adj disabled\n");
+    }
+    if (no_freq_corr) {
+        rade_rx_set_freq_corr(r, 0);
+        fprintf(stderr, "freq_corr disabled\n");
+    }
+    if (impulse_bpf) {
+        rade_rx_set_impulse_bpf(r);
+        fprintf(stderr, "impulse BPF: h[50]=1.0 (pure 50-sample delay)\n");
+    }
+    FILE *fbpf_out = NULL;
+    if (write_bpf_out) {
+        fbpf_out = fopen(write_bpf_out, "wb");
+        if (!fbpf_out) {
+            fprintf(stderr, "error: cannot open %s for writing\n", write_bpf_out);
+            return 1;
+        }
+        rade_rx_set_bpf_out_file(r, fbpf_out);
+        fprintf(stderr, "writing BPF output to %s\n", write_bpf_out);
     }
 
     int nin_max = rade_nin_max(r);
@@ -214,9 +272,8 @@ int main(int argc, char *argv[]) {
     }
 
     /* Cleanup */
-    if (feoo_bits) {
-        fclose(feoo_bits);
-    }
+    if (feoo_bits) fclose(feoo_bits);
+    if (fbpf_out)  fclose(fbpf_out);
     free(rx_in);
     free(features_out);
     free(eoo_out);

--- a/src/rade_api.c
+++ b/src/rade_api.c
@@ -257,6 +257,34 @@ void rade_rx_set_agc(struct rade *r, int enable) {
     if (r->flags & RADE_MODE_V2) r->rx_v2.agc_en = enable;
 }
 
+void rade_rx_set_bpf(struct rade *r, int enable) {
+    assert(r != NULL);
+    if (r->flags & RADE_MODE_V2) r->rx_v2.bpf_en = enable;
+}
+
+void rade_rx_set_timing_adj(struct rade *r, int enable) {
+    assert(r != NULL);
+    if (r->flags & RADE_MODE_V2) r->rx_v2.timing_adj = enable;
+}
+
+void rade_rx_set_freq_corr(struct rade *r, int enable) {
+    assert(r != NULL);
+    if (r->flags & RADE_MODE_V2) r->rx_v2.freq_offset_en = enable;
+}
+
+void rade_rx_set_impulse_bpf(struct rade *r) {
+    assert(r != NULL);
+    if (r->flags & RADE_MODE_V2) {
+        memset(r->rx_v2.bpf.h, 0, sizeof(r->rx_v2.bpf.h));
+        r->rx_v2.bpf.h[50] = 1.0f;
+    }
+}
+
+void rade_rx_set_bpf_out_file(struct rade *r, FILE *fp) {
+    assert(r != NULL);
+    if (r->flags & RADE_MODE_V2) r->rx_v2.bpf_out_fp = fp;
+}
+
 void rade_tx_set_data_symbol(struct rade *r, float symbol) {
     assert(r != NULL);
     if (r->flags & RADE_MODE_V2) rade_tx_v2_set_data_symbol(&r->tx_v2, symbol);

--- a/src/rade_api.h
+++ b/src/rade_api.h
@@ -37,6 +37,7 @@
 #ifndef __RADE_API__
 #define __RADE_API__
 
+#include <stdio.h>
 #include <sys/types.h>
 
 #if IS_BUILDING_RADE_API
@@ -187,6 +188,11 @@ RADE_EXPORT float rade_rx_get_data_symbol(struct rade *r);
 // peak range -- AGC corrects mismatches within that window, not arbitrary
 // input levels).
 RADE_EXPORT void rade_rx_set_agc(struct rade *r, int enable);
+RADE_EXPORT void rade_rx_set_bpf(struct rade *r, int enable);
+RADE_EXPORT void rade_rx_set_timing_adj(struct rade *r, int enable);
+RADE_EXPORT void rade_rx_set_freq_corr(struct rade *r, int enable);
+RADE_EXPORT void rade_rx_set_impulse_bpf(struct rade *r); /* replace BPF with pure delay h[50]=1 */
+RADE_EXPORT void rade_rx_set_bpf_out_file(struct rade *r, FILE *fp); /* dump post-BPF samples to file */
 
 #ifdef __cplusplus
 }

--- a/src/rade_bpf_filter.c
+++ b/src/rade_bpf_filter.c
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------*\
+
+  rade_bpf_filter.c
+
+  Standalone BPF filter: reads IQ f32 from stdin in chunks, applies the
+  V2 BPF, writes filtered IQ f32 to stdout.  Useful for listening to the
+  BPF output (pipe through sox) to check for clicking/buffer-edge artefacts.
+
+  Usage:
+    cat signal.f32 | ./rade_bpf_filter [chunk_size] > filtered.f32
+    sox -t f32 -r 8000 -c 2 filtered.f32 filtered.wav
+
+  chunk_size defaults to 160 (V2 sym_len).  Try 120 and 200 to exercise
+  the sizes that timing_adj produces.
+
+\*---------------------------------------------------------------------------*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "rade_bpf.h"
+#include "rade_dsp.h"
+
+#define FS          8000
+#define BANDWIDTH   974.999942f
+#define CENTRE      1468.750067f
+#define NTAP        101
+#define MAX_CHUNK   (160 + 40 + NTAP)  /* sym_len + timing_shift margin */
+
+int main(int argc, char *argv[]) {
+    int chunk = (argc >= 2) ? atoi(argv[1]) : 160;
+    if (chunk <= 0 || chunk > MAX_CHUNK) {
+        fprintf(stderr, "rade_bpf_filter: chunk_size must be 1..%d\n", MAX_CHUNK);
+        return 1;
+    }
+    fprintf(stderr, "rade_bpf_filter: BPF bw=%.1f Hz centre=%.1f Hz ntap=%d chunk=%d\n",
+            BANDWIDTH, CENTRE, NTAP, chunk);
+
+    rade_bpf bpf;
+    rade_bpf_init(&bpf, NTAP, (float)FS, BANDWIDTH, CENTRE, chunk);
+
+    RADE_COMP in[MAX_CHUNK], out[MAX_CHUNK];
+    size_t n;
+    while ((n = fread(in, sizeof(RADE_COMP), chunk, stdin)) > 0) {
+        if ((int)n < chunk)
+            memset(&in[n], 0, (chunk - n) * sizeof(RADE_COMP));
+        rade_bpf_process(&bpf, out, in, chunk);
+        fwrite(out, sizeof(RADE_COMP), n, stdout);
+    }
+    return 0;
+}

--- a/src/rade_rx_v2.c
+++ b/src/rade_rx_v2.c
@@ -38,6 +38,7 @@
 #include "rade_dec_v2_data.h"
 #include "rade_v2_constants.h"
 #include "rade_dsp.h"
+#include <assert.h>
 #include <string.h>
 #include <math.h>
 #include <stdio.h>
@@ -80,6 +81,9 @@ int rade_rx_v2_init(rade_rx_v2_state *rx, int bpf_en) {
     /* Initialise sub-components */
     rade_v2_ofdm_init(&rx->ofdm);
     rade_init_decoder_v2(&rx->dec_state);
+
+    rx->timing_adj = 1;
+    rx->freq_offset_en = 1;
 
     /* BPF */
     rx->bpf_en = bpf_en;
@@ -157,6 +161,7 @@ static void compute_autocorr(rade_rx_v2_state *rx) {
         float     D_cp  = 0.0f;
         float     D_m   = 0.0f;
 
+        assert(idx - Ncp >= 0 && idx - Ncp + M + Ncp - 1 < RADE_V2_RX_BUF_SIZE);
         for (int k = 0; k < Ncp; k++) {
             RADE_COMP a = rx->rx_buf[idx - Ncp + k];
             RADE_COMP b = rx->rx_buf[idx - Ncp + M + k];
@@ -225,12 +230,19 @@ static void extract_symbol(rade_rx_v2_state *rx) {
     int M       = RADE_V2_M;
 
     int delta_hat_rx = (int)rx->delta_hat - Ncp;
-    float omega = 2.0f * (float)M_PI * rx->freq_offset / (float)RADE_FS;
+    float omega = rx->freq_offset_en
+                  ? 2.0f * (float)M_PI * rx->freq_offset / (float)RADE_FS
+                  : 0.0f;
 
     /* Shift rx_i left by one symbol */
     memmove(rx->rx_i, &rx->rx_i[sym_len], sizeof(RADE_COMP) * sym_len);
 
     int st = sym_len + delta_hat_rx;
+    assert(st >= 0 && st + sym_len <= RADE_V2_RX_BUF_SIZE);
+
+    if (rx->verbose >= 3)
+        fprintf(stderr, "extract_symbol: delta_hat=%.1f delta_hat_rx=%d st=%d\n",
+                rx->delta_hat, delta_hat_rx, st);
 
     /* Apply continuous phase rotation, store in rx_i[sym_len..] and rx_sym_td */
     for (int n = 0; n < sym_len; n++) {
@@ -392,6 +404,8 @@ int rade_rx_v2_process(rade_rx_v2_state *rx, float *features_out,
         rade_bpf_process(&rx->bpf, rx_filtered, rx_in, nin);
         rx_samples = rx_filtered;
     }
+    if (rx->bpf_out_fp)
+        fwrite(rx_samples, sizeof(RADE_COMP), nin, rx->bpf_out_fp);
 
     /* --- AGC --- */
     RADE_COMP rx_scaled[RADE_V2_SYM_LEN + TIMING_SHIFT];

--- a/src/rade_rx_v2.h
+++ b/src/rade_rx_v2.h
@@ -42,6 +42,7 @@
 #ifndef RADE_RX_V2_H
 #define RADE_RX_V2_H
 
+#include <stdio.h>
 #include "rade_v2_ofdm.h"
 #include "rade_dec_v2.h"
 #include "rade_dec_v2_data.h"
@@ -88,6 +89,7 @@ typedef struct {
     int   s;              /* Symbol counter */
     int   i;              /* Output frame counter */
     int   timing_adj;     /* Enable timing adjustment after n symbols */
+    int   freq_offset_en; /* Enable frequency offset correction in extract_symbol */
     int   n_acq;          /* Number of acquisitions */
     int   hangover;       /* Hangover symbols before un-sync (default 75) */
 
@@ -137,6 +139,9 @@ typedef struct {
 
     /* Verbosity */
     int verbose;
+
+    /* Optional BPF output dump: if non-NULL, write post-BPF samples here each call */
+    FILE *bpf_out_fp;
 
 } rade_rx_v2_state;
 


### PR DESCRIPTION
**This is DR's WIP debug code - do not review or merge**

Investigating Issue #8: loss varies with prepend_noise delay when the V2 BPF is enabled, but is flat when the BPF is disabled.

New radae_rx CLI options (V2 only):
  --no_bpf          Disable input BPF
  --no_timing_adj   Disable timing adjustment
  --no_freq_corr    Disable frequency offset correction
  --impulse_bpf     Replace BPF with pure 50-sample delay (h[50]=1.0)
  --write_bpf_out   Dump post-BPF IQ samples to file for comparison
                    with standalone rade_bpf_filter output

New rade_api setters: rade_rx_set_bpf, rade_rx_set_timing_adj, rade_rx_set_freq_corr, rade_rx_set_impulse_bpf,
rade_rx_set_bpf_out_file.

Also adds rade_bpf_filter standalone tool: reads IQ f32 from stdin in fixed chunks, applies the V2 BPF, writes to stdout. Useful for comparing BPF output between the full receiver path and a clean standalone application.

Also fixes -v verbosity parsing to support levels 0/2/3.

The issues seems to go away when BPF is disabled, however so far no problems with BPF.

```
# Vanilla (real BPF): loss varies with delay
  WAV=wav/brian_g8sez.wav ./test/v2_c_timing.sh 0.012 0.015 2

  # No BPF: loss is flat (timing correction working correctly)
  WAV=wav/brian_g8sez.wav RX_OPTS="--no_bpf" ./test/v2_c_timing.sh 0.012 0.015 2
  
  # Impulse BPF (h[50]=1, pure delay): variation is even worse
  WAV=wav/brian_g8sez.wav RX_OPTS="--impulse_bpf" ./test/v2_c_timing.sh 0.012 0.015 2

  Expected output (from earlier runs):

  --- vanilla ---
  delay        py_dhat      c_dhat       py_loss    c_loss
  0.012000     58.04        58.0         0.089      0.091
  0.013500     70.04        70.7         0.089      0.089
  0.015000     42.04        42.0         0.089      0.096   ← variation
  
  --- no_bpf ---
  0.012000     58.04        88.0         0.089      0.087
  0.013500     70.04        100.0        0.089      0.088
  0.015000     42.04        112.0        0.089      0.087   ← flat

  --- impulse_bpf ---
  0.012000     58.04        58.0         0.089      0.098
  0.013500     70.04        70.0         0.089      0.093
  0.015000     42.04        42.0         0.089      0.103   ← worse variation

```
