### PR TITLE
V2 AGC Fix & misc bug fixes

### DIFF
--- a/src/radae_rx.c
+++ b/src/radae_rx.c
@@ -85,11 +85,13 @@ int main(int argc, char *argv[]) {
         case 'm':
             model_name = optarg;
             break;
-        case 'v':
-            if (atoi(optarg) == 0) {
-                flags |= RADE_VERBOSE_0;
-            }
+        case 'v': {
+            int v = atoi(optarg);
+            if (v == 0)      flags |= RADE_VERBOSE_0;
+            else if (v == 2) flags |= RADE_VERBOSE_TERSE;
+            else if (v >= 3) flags |= RADE_VERBOSE_FULL;
             break;
+        }
         case 'd':
             disable_unsync = atof(optarg);
             break;

--- a/src/rade_bpf.c
+++ b/src/rade_bpf.c
@@ -108,5 +108,7 @@ void rade_bpf_process(rade_bpf *bpf, RADE_COMP *y, const RADE_COMP *x, int n) {
     }
 
     /* Save phase state for next call */
+    float phase_mag = rade_cabs(phase);
+    phase = rade_cscale(phase, 1.0/phase_mag);
     bpf->phase = phase;
 }

--- a/src/rade_rx.c
+++ b/src/rade_rx.c
@@ -233,8 +233,8 @@ int rade_rx_process(rade_rx_state *rx, float *features_out, float *eoo_out, cons
         rx->rx_phase = rx_phase;
 
         /* Normalize phase to prevent drift */
-        //float phase_mag = rade_cabs(rx->rx_phase);
-        //rx->rx_phase = rade_cscale(rx->rx_phase, 1.0f / phase_mag);
+        float phase_mag = rade_cabs(rx->rx_phase);
+        rx->rx_phase = rade_cscale(rx->rx_phase, 1.0f / phase_mag);
 
         /* Demodulate OFDM frame */
         float z_hat[RADE_NZMF * RADE_LATENT_DIM];

--- a/src/rade_rx_v2.c
+++ b/src/rade_rx_v2.c
@@ -300,6 +300,7 @@ static int update_frame_sync_decode(rade_rx_v2_state *rx,
     for (int f = 0; f < frames; f++) {
         float *dst = &features_out[f * nb_total];
         float *src = &dec_features[f * num_feat];
+        if (src[18] < -1.4f) src[18] = -1.4f;   /* limit_pitch, matches radae_v2.py default */
         for (int j = 0; j < num_used; j++)
             dst[j] = src[j];
     }

--- a/src/rade_rx_v2.c
+++ b/src/rade_rx_v2.c
@@ -38,6 +38,7 @@
 #include "rade_dec_v2_data.h"
 #include "rade_v2_constants.h"
 #include "rade_dsp.h"
+#include <assert.h>
 #include <string.h>
 #include <math.h>
 #include <stdio.h>
@@ -114,6 +115,7 @@ int rade_rx_v2_init(rade_rx_v2_state *rx, int bpf_en) {
        off by the ~3dB PAPR, matching radae_v2.py's agc_target. */
     rx->agc_en     = 1;
     rx->agc_target = 1.0f * powf(10.0f, -3.0f / 20.0f);
+    rx->agc_power  = rx->agc_target * rx->agc_target;
 
     /* Phase rotator starts at 1+0j */
     rx->rx_phase.real = 1.0f;
@@ -159,6 +161,7 @@ static void compute_autocorr(rade_rx_v2_state *rx) {
         float     D_cp  = 0.0f;
         float     D_m   = 0.0f;
 
+        assert(idx - Ncp >= 0 && idx - Ncp + M + Ncp - 1 < RADE_V2_RX_BUF_SIZE);
         for (int k = 0; k < Ncp; k++) {
             RADE_COMP a = rx->rx_buf[idx - Ncp + k];
             RADE_COMP b = rx->rx_buf[idx - Ncp + M + k];
@@ -233,6 +236,7 @@ static void extract_symbol(rade_rx_v2_state *rx) {
     memmove(rx->rx_i, &rx->rx_i[sym_len], sizeof(RADE_COMP) * sym_len);
 
     int st = sym_len + delta_hat_rx;
+    assert(st >= 0 && st + sym_len <= RADE_V2_RX_BUF_SIZE);
 
     /* Apply continuous phase rotation, store in rx_i[sym_len..] and rx_sym_td */
     for (int n = 0; n < sym_len; n++) {
@@ -359,19 +363,23 @@ static int adjust_timing(rade_rx_v2_state *rx) {
                                   AGC
 \*---------------------------------------------------------------------------*/
 
-/* Instantaneous gain to bring rx_in's RMS to agc_target, clipped to
-   +/-20dB. Matches radae_v2.py's _compute_gain(). */
-static float compute_gain(const rade_rx_v2_state *rx, const RADE_COMP *rx_in, int nin) {
+#define AGC_ALPHA 0.99875f  /* IIR filter coeff for AGC power estimate, tau~0.1s @ Fs=8000 */
+
+/* Gain to bring rx_in's RMS to agc_target, clipped to +/-20dB. Power
+   estimate is a persistent per-sample IIR average (rx->agc_power) --
+   matches radae_v2.py's _compute_gain(). */
+static float compute_gain(rade_rx_v2_state *rx, const RADE_COMP *rx_in, int nin) {
     if (!rx->agc_en)
         return 1.0f;
 
-    float sum_sq = 0.0f;
+    float p = rx->agc_power;
     for (int i = 0; i < nin; i++) {
-        sum_sq += rx_in[i].real * rx_in[i].real + rx_in[i].imag * rx_in[i].imag;
+        float mag_sq = rx_in[i].real * rx_in[i].real + rx_in[i].imag * rx_in[i].imag;
+        p = AGC_ALPHA * p + (1.0f - AGC_ALPHA) * mag_sq;
     }
-    float rms  = sqrtf(sum_sq / (float)nin);
-    float gain = rx->agc_target / (rms + 1e-6f);
+    rx->agc_power = p;
 
+    float gain = rx->agc_target / (sqrtf(p) + 1e-6f);
     if (gain < 0.1f) gain = 0.1f;
     if (gain > 10.0f) gain = 10.0f;
     return gain;

--- a/src/rade_rx_v2.c
+++ b/src/rade_rx_v2.c
@@ -81,6 +81,8 @@ int rade_rx_v2_init(rade_rx_v2_state *rx, int bpf_en) {
     rade_v2_ofdm_init(&rx->ofdm);
     rade_init_decoder_v2(&rx->dec_state);
 
+    rx->timing_adj = 1;
+
     /* BPF */
     rx->bpf_en = bpf_en;
     if (bpf_en) {

--- a/src/rade_rx_v2.h
+++ b/src/rade_rx_v2.h
@@ -92,9 +92,12 @@ typedef struct {
     int   hangover;       /* Hangover symbols before un-sync (default 75) */
 
     /* Input AGC: normalises rx sample RMS to agc_target before buffering,
-       clipped to +/-20dB (0.1 to 10.0 gain). On by default. */
+       clipped to +/-20dB (0.1 to 10.0 gain). On by default. Gain is derived
+       from a persistent IIR-smoothed power estimate (agc_power), matching
+       radae_v2.py's _compute_gain(). */
     int   agc_en;
     float agc_target;
+    float agc_power;
 
     /* Timing / frequency tracking */
     float delta_hat;      /* IIR-smoothed timing offset */


### PR DESCRIPTION
Attempts to address Issues #8 #14 #16 #15.  The main innovation is a IIR smoothed AGC rather than simple block based which was the root cause of Issue #8.

Using https://github.com/drowe67/radae/pull/70/commits/b89a3298111973107e83fc70d28ed6058e1eccd2, we can test Python versus C to see if loss versus delay is flat:
```
PY_OPTS="--agc" ./test/v2_c_timing.sh 0 0.02 4
delay        py_dhat      c_dhat       py_loss    c_loss    
------------ ------------ ------------ ---------- ----------
0.000000     82.26        82           0.082      0.081     
0.005000     82.25        82           0.082      0.081     
0.010000     82.00        82           0.082      0.081     
0.015000     42.26        42           0.081      0.081     
0.020000     82.26        82           0.081      0.081     
------------ ------------ ------------ ---------- ----------
                          stddev:      0.0005     0.0000    
```

The performance of the AGC has been analysed and reported in the v2 test report, also in https://github.com/drowe67/radae/pull/70/commits/b89a3298111973107e83fc70d28ed6058e1eccd2, and looks robust to timing offsets now.