### PR TITLE
CI: point radae checkout at main instead of dr-radev2

### DIFF
--- a/.github/workflows/run_ctest.yml
+++ b/.github/workflows/run_ctest.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: drowe67/radae
-          ref: dr-radev2
+          ref: main
           path: ${{github.workspace}}/radae
 
       - name: Build radae


### PR DESCRIPTION
dr-radev2 has been merged into radae's main (drowe67/radae#70), so CI's checkout of the Python reference tools should track main going forward.